### PR TITLE
added comment if someone ever needs to debug this again

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,16 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Python: Current File",
+            "type": "python",
+            "request": "launch",
+            "program": "${file}",
+            "console": "integratedTerminal",
+            "justMyCode": false
+        }
+    ]
+}

--- a/freespeech/lib/tts.py
+++ b/freespeech/lib/tts.py
@@ -136,6 +136,10 @@ async def synthesize(
         return await synthesize(events, lang, output_dir, False)
 
     output_file = str(Path(output_dir) / f"{uuid4()}.wav")
+    # If the function call below this gets a cryptic error message involving
+    # struct.pack('<L4s4sLHHLLHH4s', ...), it's probably because a timestamp
+    # of an event is at a spot greater then 10hrs. This is a limitation of pydub,
+    # and also shouldn't happen in the first place.
     fd = res.export(output_file, format="wav")
     fd.close()  # type: ignore
 


### PR DESCRIPTION
Dubbing was broken because the transcript had an event at 7 and 10hrs in, which would've produced a wav file over 7gb in length. Luckily, it failed when trying to write the length of the file into the wav header -- it didn't fit in the space allotted (limit was an integer no greater than 4 * 10^9, but the size was 7 * 10^9). It did however take that much in memory, which led to an out of memory error in the gce instance.